### PR TITLE
Fix hashes.bin filestream error on Linux

### DIFF
--- a/src/core/resource/IdResolver.cpp
+++ b/src/core/resource/IdResolver.cpp
@@ -38,6 +38,14 @@ namespace msml::core::resource {
 
         hashes32.clear();
         hashes64.clear();
+
+        if (stream->GetState() != EA::IO::FileError::Success || stream->GetAccessFlags() == EA::IO::AccessFlags::None) {
+            MSML_LOG_ERROR("Failed to load Hashes from %s", path.c_str());
+            stream->Close();
+            stream->Release();
+            return; // exit early instead of trying to read from invalid stream
+        }
+
         uint64_t count;
         READ(stream, count);
 


### PR DESCRIPTION
When `hashes.bin` does not exist or is otherwise not usable the filestream will be invalid. This has seemingly no consequences on Windows but will prevent the game from booting on Linux with Proton. This PR introduces an early exit condition in the `IdResolver` class to handle invalid file streams.

Error handling improvement:

* `src/core/resource/IdResolver.cpp`: Added a check to verify the file stream's state and access flags before proceeding. If the stream is invalid, an error is logged and the function exits early to avoid attempting to read from an invalid stream.